### PR TITLE
Fix Reverse in Load/Save Project

### DIFF
--- a/src/mobius/AboutDialog.cpp
+++ b/src/mobius/AboutDialog.cpp
@@ -7,7 +7,7 @@
  * 
  */
 
-#include <stdio.h>
+#include <stdio.h> 
 #include <stdlib.h>
 #include <math.h>
 
@@ -16,7 +16,7 @@
 
 #include "UI.h"
 
-#define VERSION "Möbius version 2.5"
+#define VERSION "Möbius version 2.5.1 [alpha Build 1 x86 / 2023]"
 
 PUBLIC AboutDialog::AboutDialog(Window* parent)
 {
@@ -34,6 +34,7 @@ PUBLIC AboutDialog::AboutDialog(Window* parent)
 
 	text->add(new Label(VERSION));
 	text->add(new Label("Copyright (c) 2005-2012 Jeffrey S. Larson"));
+	text->add(new Label("Build 1/23 - 13/04/2023 | ClaudioCas"));
 	text->add(new Label("All rights reserved."));
 
     // TODO: Need to credit Oli for pitch shifting, link

--- a/src/mobius/Project.cpp
+++ b/src/mobius/Project.cpp
@@ -818,7 +818,7 @@ void ProjectLoop::parseXml(XmlElement* e)
 {
 	mActive = e->getBoolAttribute(ATT_ACTIVE);
 	mFrame = e->getIntAttribute(ATT_FRAME);
-
+	
 	for (XmlElement* child = e->getChildElement() ; child != NULL ; 
 		 child = child->getNextElement()) {
 
@@ -856,6 +856,9 @@ PUBLIC ProjectTrack::ProjectTrack(MobiusConfig* config, Project* p, Track* t)
 	mFeedback = t->getFeedback();
 	mAltFeedback = t->getAltFeedback();
 	mPan = t->getPan();
+	
+	//@C #001 Fix issue about Track reverse wrong saved and load form project 08/04/2023
+	mReverse =  t->getState()->reverse;  //@C 
 
     mSpeedOctave = t->getSpeedOctave();
     mSpeedStep = t->getSpeedStep();
@@ -891,6 +894,7 @@ PUBLIC ProjectTrack::ProjectTrack(MobiusConfig* config, Project* p, Track* t)
 		  pl->setActive(true);
 		add(pl);
 	}
+	
 }
 
 PUBLIC void ProjectTrack::init()
@@ -904,6 +908,7 @@ PUBLIC void ProjectTrack::init()
 	mFeedback = 127;
 	mAltFeedback = 127;
 	mPan = 64;
+	mReverse = false;  //@C init mReverse to false #001
     mSpeedOctave = 0;
     mSpeedStep = 0;
     mSpeedBend = 0;
@@ -1214,8 +1219,11 @@ void ProjectTrack::toXml(XmlBuffer* b, bool isTemplate)
     b->addAttribute(ATT_ALT_FEEDBACK, mAltFeedback);
     b->addAttribute(ATT_PAN, mPan);
 
+	//@C debug #001
+	Trace(3, "[CasDebug]:toXML* ATT_REVERSE! is : %s", mReverse ? "true" : "false");
     b->addAttribute(ATT_REVERSE, mReverse);
-    b->addAttribute(ATT_SPEED_OCTAVE, mSpeedOctave);
+    
+	b->addAttribute(ATT_SPEED_OCTAVE, mSpeedOctave);
     b->addAttribute(ATT_SPEED_STEP, mSpeedStep);
     b->addAttribute(ATT_SPEED_BEND, mSpeedBend);
     b->addAttribute(ATT_SPEED_TOGGLE, mSpeedToggle);
@@ -1260,6 +1268,13 @@ void ProjectTrack::parseXml(XmlElement* e)
 	setAltFeedback(e->getIntAttribute(ATT_ALT_FEEDBACK));
 	setPan(e->getIntAttribute(ATT_PAN));
 
+	//@C #001 cas : here miss some set? or the next rows of code load "reverse"?
+	Trace(3, "[CasDebug]:parseXML* ATT_REVERSE! is : %s", e->getBoolAttribute(ATT_REVERSE) ? "true" : "false");
+	setReverse(e->getBoolAttribute(ATT_REVERSE));  //08/04/2023 //@C <-- now load correctly but still save issue -> toXml mReverse is true...
+	
+
+
+	//@C read all child in xml, they can be UserVariables or Loop
 	for (XmlElement* child = e->getChildElement() ; child != NULL ; 
 		 child = child->getNextElement()) {
 
@@ -1268,7 +1283,10 @@ void ProjectTrack::parseXml(XmlElement* e)
 			mVariables = new UserVariables(child);
 		}
 		else
+		{
+			// cas: if is not a Variable Name is a loop, so load loop?
 		  add(new ProjectLoop(child));
+		}
 	}
 }
 

--- a/src/mobius/Track.cpp
+++ b/src/mobius/Track.cpp
@@ -1516,7 +1516,11 @@ void Track::loadProject(ProjectTrack* pt)
 	setPan(pt->getPan());
 	setFocusLock(pt->isFocusLock());
 
-	mInput->setReverse(pt->isReverse());
+    //@C Check Track isReverse #001 [first attempt, but if there is a loop in the trace, the value is then reset to false]
+    //Trace(3, "[CasDebug]:loadProject ,Input->setReverse() :  %s", (pt->isReverse() ? "true" : "false"));
+	//mInput->setReverse(pt->isReverse());
+    //@C see above the fix in the rigt place
+
 
     // TODO: pitch and speed
     /*
@@ -1559,6 +1563,11 @@ void Track::loadProject(ProjectTrack* pt)
 		if (pl->isActive())
 		  mLoop = mLoops[i];
 	}
+
+     //@C Set the mInput Track Reverse #001 | fix issue! [loadProject reset track isReverse]
+    Trace(3, "[CasDebug]:loadProject ,Input->setReverse() :  %s", (pt->isReverse() ? "true" : "false"));
+	mInput->setReverse(pt->isReverse());
+
 }
 
 /****************************************************************************


### PR DESCRIPTION
1 - Save Mop Reverse Issue - Fixed issue about Reverse Function of tracks. In mos file (toXml) the Reverse was always true. Fixed

2 - Loading Mop Reverse Issue - The Reverse attribute was ignored during loading. Every track without loop was setting with reverse= true and all the tracks with loop with reverse=false. Fixed